### PR TITLE
Remove unneeded apt_source dependency

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,16 +15,3 @@ nginx_access_log: '/var/log/nginx/cache.log cache;'
 # don't cache requests with PHP session cookie.
 nginx_bypass_cache_cookies:
   - ~SESS
-
-apt_source_definitions:
-  Ubuntu:
-    source: ppa:nginx/stable
-    packages:
-      - pattern: '*nginx*'
-  Debian:
-    source: deb http://packages.dotdeb.org {{ansible_lsb.codename}} all
-    key:
-      url: http://www.dotdeb.org/dotdeb.gpg
-      id: 89DF5277
-    packages:
-      - pattern: '*nginx*'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -117,10 +117,6 @@ galaxy_info:
   #- system
   #- web
 dependencies:
-  - role: ajsalminen.apt_source
-    apt_source_config:
-      - "{{apt_source_definitions.get(ansible_distribution)}}"
-    when: nginx_enable_source == True and (ansible_distribution != "Debian" or ansible_distribution_major_version|int < 10)  # XXX: need to be handled elsewhere
   - role: ajsalminen.nginx_site
     when: nginx_disable_default == False
   - role: ajsalminen.nginx_common

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -120,7 +120,7 @@ dependencies:
   - role: ajsalminen.apt_source
     apt_source_config:
       - "{{apt_source_definitions.get(ansible_distribution)}}"
-    when: nginx_enable_source == True
+    when: nginx_enable_source == True and (ansible_distribution != "Debian" or ansible_distribution_major_version|int < 10)  # XXX: need to be handled elsewhere
   - role: ajsalminen.nginx_site
     when: nginx_disable_default == False
   - role: ajsalminen.nginx_common


### PR DESCRIPTION
Dotdeb is not updated anymore and does not work with Debian 10.

This is a bit hacky solution that should be solved somewhere else.
Perhaps, the apt_source_definitions structure could include the major
version of the distribution.